### PR TITLE
Fix/find support service

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ https://dxw.zendesk.com/agent/tickets/123345?zat=true
 
 Click on the `Apps` button on the ticket view to see the app in action!
 
+If the sidebar will not load, check the console. If you see a request to https://localhost and an error about SSL, then you may need to make changs in your browser to enable this ([for Chrome see here](https://stackoverflow.com/a/59452249/3356802).
+
 ## Running the tests
 
 Jest is used for testing, and all tests, mocks, and fixtures are in the `spec` folder.

--- a/spec/app.spec.js
+++ b/spec/app.spec.js
@@ -81,7 +81,7 @@ describe('Example App', () => {
     })
 
     it('should show an error message on the page', () => {
-      expect(document.querySelector('#message').textContent).toMatch('Could not find Productive project URL in Airtable project')
+      expect(document.querySelector('#message').textContent).toMatch('Could not find Productive project URL in Airtable')
     })
   })
 

--- a/src/javascripts/lib/productive.js
+++ b/src/javascripts/lib/productive.js
@@ -66,7 +66,7 @@ class Productive {
       'filter[project_id]': projectId
     })
       .then(responseData => {
-        const supportService = responseData.data.find(service => service.relationships.service_type.data.id === this._supportServiceTypeId)
+        const supportService = responseData.data.find(service => service.relationships.service_type.data?.id === this._supportServiceTypeId)
         if (!supportService) {
           throw new Error()
         }

--- a/src/javascripts/modules/app.js
+++ b/src/javascripts/modules/app.js
@@ -29,7 +29,7 @@ class App {
     const airtableProjectRecord = await this._initializeAirtableProject(this._metadata.settings).catch(this._handleError.bind(this))
     this._productiveClient = await this._initializeProductiveClient(this._metadata.settings.productive_api_key, this._metadata.settings.productive_org_id)
     if (!airtableProjectRecord) return this._handleError('Could not find project in Airtable')
-    if (!airtableProjectRecord.productive_url) return this._handleError('Could not find Productive project URL in Airtable project')
+    if (!airtableProjectRecord.productive_url) return this._handleError('Could not find Productive project URL in Airtable')
     if (!this._productiveClient) return this._handleError('Could not connect to Productive')
 
     const projectId = this._productiveClient.getProjectIdFromUrl(airtableProjectRecord.productive_url)


### PR DESCRIPTION
# Context
We had a weird error where the app would report that no support service existed for a project, even though one did.

It turns out that this happens when a project has a services like Open Hours that doesn't have a service type. When we try to check the service type, an error occurs, which breaks the loop and prevents the other services on the project from being checked.

# This PR
This PR fixes the problem by converting the chaining operator to be optional (`?.`). That means that instead of throwing an error we get an undefined response and can test the next item in the array.

Fixing this problem was delayed because we couldn't get a test version of the app working because of a localhost SSL issue, so I've added a note to the readme about how to fix this.