### PR TITLE
Fix slow sync task blocking widget loading

### DIFF
--- a/src/javascripts/modules/app.js
+++ b/src/javascripts/modules/app.js
@@ -14,7 +14,7 @@ class App {
     this._data = {}
 
     // this.initializePromise is only used in testing
-    // indicate app initilization(including all async operations) is complete
+    // indicate app initilization (including all async operations) is complete
     this.initializePromise = this.init()
   }
 

--- a/src/javascripts/modules/app.js
+++ b/src/javascripts/modules/app.js
@@ -47,7 +47,16 @@ class App {
       this._data.person = person
       this._data.project = project
 
-      const ticketTimeEntries = await this._productiveClient.getTimeEntriesContaining(this._ticket.id)
+      this._productiveClient.getTimeEntriesContaining(this._ticket.id)
+        .then(ticketTimeEntries => {
+          console.log('Retrieved time entries from Productive')
+          this.states.ticket = {
+            hours: this._convertToHours(ticketTimeEntries.reduce((total, entry) => total + entry.attributes.time, 0))
+          }
+          console.log('Rendering...')
+          this._renderTemplate()
+        })
+        .catch(this._handleError.bind(this))
 
       return this._productiveClient.getProjectSupportService(projectId, deals.map(deal => deal.id))
         .then(service => {
@@ -70,8 +79,6 @@ class App {
             name: this._data.project.attributes.name,
             url: productiveBaseUrl + 'projects/' + this._data.project.id + '/time-entries'
           }
-
-          this.states.ticket = { hours: this._convertToHours(ticketTimeEntries.reduce((total, entry) => total + entry.attributes.time, 0)) }
 
           this.states.okay = true
           this._renderTemplate()

--- a/src/javascripts/modules/app.js
+++ b/src/javascripts/modules/app.js
@@ -80,6 +80,12 @@ class App {
             url: productiveBaseUrl + 'projects/' + this._data.project.id + '/time-entries'
           }
 
+          if (!this.states?.ticket?.hours) {
+            this.states.ticket = {
+              hours: '[calculating...]'
+            }
+          }
+
           this.states.okay = true
           this._renderTemplate()
           document.getElementById('note').value = this._ticket.subject


### PR DESCRIPTION
# Context

@mattymaxwell [flagged a problem](https://dxw.slack.com/archives/C01VAEC7TUJ/p1644577385429729) where the logger was extremely slow to load (~15 seconds).

I investigated and found that the root cause was a synchronous call to Productive. We get several pieces of information about the ticket's project from Productive. One of these is a check of how many previous time entries have referenced the current Zendesk ticket. This is quite a slow call (on Productive's side) and because it was synchronous it was blocking everything else.

# This PR

This PR makes the call asynchronous so that it's no longer a blocker. If the call takes a while then we put in a placeholder value in the meantime and replace it when the correct value is ready.

I've also added some console logs to make debugging a bit easier. This is okay because this is an internal-only tool.