### PR TITLE
Use the updated dxw fork of ZAT

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@
 source 'https://rubygems.org/'
 
 # Forked from "zendesk/zendesk_apps_tools" to fix security alerts
-gem 'zendesk_apps_tools', github: 'dxw/zendesk_apps_tools', ref: '05eb50b'
+gem 'zendesk_apps_tools', github: 'dxw/zendesk_apps_tools', ref: 'f97d15e'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,44 +1,44 @@
 GIT
   remote: https://github.com/dxw/zendesk_apps_tools.git
-  revision: 05eb50b8ca248a169a6e6e96b5932dcb6b233e33
-  ref: 05eb50b
+  revision: f97d15ec67a0f9749a8bc8fec5b98a9c11b4a1f5
+  ref: f97d15e
   specs:
-    zendesk_apps_tools (3.8.5)
+    zendesk_apps_tools (3.8.11)
       execjs (~> 2.7.0)
-      faraday (~> 0.9.2)
-      faye-websocket (~> 0.11.0)
+      faraday (~> 0.17.5)
+      faye-websocket (>= 0.10.7, < 0.12.0)
       listen (~> 2.10)
       rack-livereload
-      rubyzip (~> 1.3.0)
-      sinatra (~> 2.1.0)
+      rubyzip (>= 1.2.1, < 2.4.0)
+      sinatra (>= 1.4.6, < 2.3.0)
       sinatra-cross_origin (~> 0.3.1)
       thin (~> 1.8.0)
       thor (~> 0.19.4)
-      zendesk_apps_support (>= 4.29.10)
+      zendesk_apps_support (~> 4.32.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     celluloid (0.16.0)
       timers (~> 4.0.0)
-    concurrent-ruby (1.1.9)
+    concurrent-ruby (1.1.10)
     crass (1.0.6)
     daemons (1.4.1)
     erubis (2.7.0)
     eventmachine (1.2.7)
     execjs (2.7.0)
-    faraday (0.9.2)
+    faraday (0.17.5)
       multipart-post (>= 1.2, < 3)
     faye-websocket (0.11.1)
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
-    ffi (1.15.4)
+    ffi (1.15.5)
     hitimes (2.0.0)
-    i18n (1.8.11)
+    i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     image_size (2.0.2)
     ipaddress_2 (0.13.0)
-    json (2.6.1)
+    json (2.6.2)
     listen (2.10.1)
       celluloid (~> 0.16.0)
       rb-fsevent (>= 0.9.3)
@@ -60,13 +60,13 @@ GEM
     rack (2.2.3)
     rack-livereload (0.3.17)
       rack
-    rack-protection (2.1.0)
+    rack-protection (2.2.0)
       rack
-    rb-fsevent (0.11.0)
+    rb-fsevent (0.11.1)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     ruby2_keywords (0.0.5)
-    rubyzip (1.3.0)
+    rubyzip (2.3.2)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -74,10 +74,10 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.7)
     sassc (2.4.0)
       ffi (~> 1.9)
-    sinatra (2.1.0)
+    sinatra (2.2.0)
       mustermann (~> 1.0)
       rack (~> 2.2)
-      rack-protection (= 2.1.0)
+      rack-protection (= 2.2.0)
       tilt (~> 2.0)
     sinatra-cross_origin (0.3.2)
     thin (1.8.1)
@@ -91,7 +91,7 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zendesk_apps_support (4.29.10)
+    zendesk_apps_support (4.32.0)
       erubis
       i18n
       image_size (~> 2.0.2)
@@ -112,4 +112,4 @@ DEPENDENCIES
   zendesk_apps_tools!
 
 BUNDLED WITH
-   2.2.24
+   2.3.7


### PR DESCRIPTION
The dxw fork has been updated with the latest updates from the official
repository.

This should resolve CVE-2022-29970 for sinatra < 2.2.0.