### PR TITLE
Replace precss with precss-v8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "postcss-import": "^14.0.2",
         "postcss-loader": "^6.2.0",
         "postcss-preset-env": "^6.7.0",
-        "precss": "^4.0.0",
+        "precss-v8": "^5.0.1",
         "process": "0.11.10",
         "regenerator-runtime": "^0.13.9",
         "standard": "^16.0.3",
@@ -11906,61 +11906,25 @@
         "node": ">=6.14.4"
       }
     },
-    "node_modules/precss": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/precss/-/precss-4.0.0.tgz",
-      "integrity": "sha512-cRPZMKpHLZXR6gJlrXRjJe7SQMf+wYxg6rKp+TwYsYABjApSj9z8E8yIlagqADaWyikeIZttaNU6xqSjFIAP/g==",
+    "node_modules/precss-v8": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/precss-v8/-/precss-v8-5.0.1.tgz",
+      "integrity": "sha512-G+IEjD7e7IBDcbM1waLPXfuS1ShnE6JDay8mum8EVX91uTwJhml6IKcCH0KbIAG59RN4JOO3DG5MPVjcYVcQeA==",
       "dev": true,
       "dependencies": {
-        "postcss": "^7.0.6",
-        "postcss-advanced-variables": "^3.0.0",
+        "postcss": "^8.3.11",
+        "postcss-advanced-variables": "^3.0.1",
         "postcss-atroot": "^0.1.3",
         "postcss-extend-rule": "^2.0.0",
-        "postcss-nested": "^4.1.0",
-        "postcss-preset-env": "^6.4.0",
+        "postcss-nested": "^4.2.3",
+        "postcss-preset-env": "^6.7.0",
         "postcss-property-lookup": "^2.0.0"
       },
       "engines": {
         "node": ">=4.0.0"
-      }
-    },
-    "node_modules/precss/node_modules/postcss": {
-      "version": "7.0.36",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
-      "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^2.4.2",
-        "source-map": "^0.6.1",
-        "supports-color": "^6.1.0"
       },
-      "engines": {
-        "node": ">=6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
-      }
-    },
-    "node_modules/precss/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/precss/node_modules/supports-color": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-      "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
+      "peerDependencies": {
+        "postcss": "^8.3.11"
       }
     },
     "node_modules/prelude-ls": {
@@ -22755,47 +22719,19 @@
         "uniq": "^1.0.1"
       }
     },
-    "precss": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/precss/-/precss-4.0.0.tgz",
-      "integrity": "sha512-cRPZMKpHLZXR6gJlrXRjJe7SQMf+wYxg6rKp+TwYsYABjApSj9z8E8yIlagqADaWyikeIZttaNU6xqSjFIAP/g==",
+    "precss-v8": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/precss-v8/-/precss-v8-5.0.1.tgz",
+      "integrity": "sha512-G+IEjD7e7IBDcbM1waLPXfuS1ShnE6JDay8mum8EVX91uTwJhml6IKcCH0KbIAG59RN4JOO3DG5MPVjcYVcQeA==",
       "dev": true,
       "requires": {
-        "postcss": "^7.0.6",
-        "postcss-advanced-variables": "^3.0.0",
+        "postcss": "^8.3.11",
+        "postcss-advanced-variables": "^3.0.1",
         "postcss-atroot": "^0.1.3",
         "postcss-extend-rule": "^2.0.0",
-        "postcss-nested": "^4.1.0",
-        "postcss-preset-env": "^6.4.0",
+        "postcss-nested": "^4.2.3",
+        "postcss-preset-env": "^6.7.0",
         "postcss-property-lookup": "^2.0.0"
-      },
-      "dependencies": {
-        "postcss": {
-          "version": "7.0.36",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
-          "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
       }
     },
     "prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "postcss-import": "^14.0.2",
     "postcss-loader": "^6.2.0",
     "postcss-preset-env": "^6.7.0",
-    "precss": "^4.0.0",
+    "precss-v8": "^5.0.1",
     "process": "0.11.10",
     "regenerator-runtime": "^0.13.9",
     "standard": "^16.0.3",


### PR DESCRIPTION
`precss` says “Package no longer supported”.
(https://www.npmjs.com/package/precss)

Replace with precss-v8 to resolve security alerts.